### PR TITLE
Fix for Rackspace caching server details.

### DIFF
--- a/lib/Net/RackSpace/CloudServers.pm
+++ b/lib/Net/RackSpace/CloudServers.pm
@@ -170,6 +170,9 @@ sub get_server {
     ? ( defined $id ? '/servers/' . $id : '/servers/detail' )
     : ( defined $id ? '/servers/' . $id : '/servers' )
   );
+  # Fix for the caching that Rackspace does. This ensures that the list of
+  # returned servers is always correct.
+  $uri = $uri."?cacheid=".time();
   my $request = HTTP::Request->new(
     'GET',
     $self->server_management_url . $uri,


### PR DESCRIPTION
Not sure if you're interested, but I noticed a problem where calls to the Rackspace API for getting server details appears to be cached at the Rackspace end. This is a problem when adding new servers and then trying to get the server details for them.

This is a quick fix to add an extra parameter to the /servers and /servers/detail requests to make sure that Rackspace always see it as a new request.
